### PR TITLE
make setup of JetStreamMgmt more idiomatic with the wider ecosystem

### DIFF
--- a/jsm/act_command.go
+++ b/jsm/act_command.go
@@ -32,10 +32,10 @@ func configureActCommand(app *kingpin.Application) {
 }
 
 func (c *actCmd) infoAction(pc *kingpin.ParseContext) error {
-	nc, err := connect()
-	kingpin.FatalIfError(err, "could not connect")
+	jsm, err := NewJSM(timeout, servers, natsOpts())
+	kingpin.FatalIfError(err, "setup failed")
 
-	info, err := NewJSM(nc, timeout).AccountStats()
+	info, err := jsm.AccountStats()
 	kingpin.FatalIfError(err, "could not request account info")
 
 	if c.json {

--- a/jsm/jetstreammgmt.go
+++ b/jsm/jetstreammgmt.go
@@ -31,11 +31,16 @@ type JetStreamMgmt struct {
 }
 
 // NewJSM creates a new instance of the JetStream Management package
-func NewJSM(c *nats.Conn, timeout time.Duration) *JetStreamMgmt {
-	return &JetStreamMgmt{
-		timeout: time.Second,
-		nc:      c,
+func NewJSM(timeout time.Duration, servers string, opts []nats.Option) (jsm *JetStreamMgmt, err error) {
+	nc, err := nats.Connect(servers, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("connection failed: %v", err)
 	}
+
+	return &JetStreamMgmt{
+		timeout: timeout,
+		nc:      nc,
+	}, nil
 }
 
 // MessageSetCreate creates a new message set
@@ -218,6 +223,11 @@ func (j *JetStreamMgmt) AccountStats() (info *api.JetStreamAccountStats, err err
 // Flush calls flush on the underlying nats connection
 func (j *JetStreamMgmt) Flush() {
 	j.nc.Flush()
+}
+
+// Nats provides access to the underlying NATS client
+func (j *JetStreamMgmt) Nats() *nats.Conn {
+	return j.nc
 }
 
 func (j *JetStreamMgmt) requestAndUnMarshal(t string, payload []byte, target interface{}) (err error) {

--- a/jsm/jetstreammgmt_test.go
+++ b/jsm/jetstreammgmt_test.go
@@ -38,10 +38,8 @@ func setupJSMTest(t *testing.T) (srv *natsd.Server, nc *nats.Conn, jsm *JetStrea
 		t.Errorf("nats server did not start")
 	}
 
-	nc, err = nats.Connect(srv.ClientURL())
+	jsm, err = NewJSM(time.Second, srv.ClientURL(), []nats.Option{})
 	checkErr(t, err, "could not connect client to server @ %s: %v", srv.ClientURL(), err)
-
-	jsm = NewJSM(nc, time.Second)
 
 	sets, err := jsm.MessageSets()
 	checkErr(t, err, "could not load sets: %v", err)
@@ -49,7 +47,7 @@ func setupJSMTest(t *testing.T) (srv *natsd.Server, nc *nats.Conn, jsm *JetStrea
 		t.Fatalf("found %v message sets but it should be empty", sets)
 	}
 
-	return srv, nc, jsm
+	return srv, jsm.Nats(), jsm
 }
 
 func setupObsTest(t *testing.T) (srv *natsd.Server, nc *nats.Conn, jsm *JetStreamMgmt) {

--- a/jsm/obs_command.go
+++ b/jsm/obs_command.go
@@ -299,10 +299,8 @@ func (c *obsCmd) nextAction(pc *kingpin.ParseContext) error {
 }
 
 func (c *obsCmd) connectAndSetup(askSet bool, askObs bool) (jsm *JetStreamMgmt) {
-	nc, err := connect()
-	kingpin.FatalIfError(err, "could not connect")
-
-	jsm = NewJSM(nc, timeout)
+	jsm, err := NewJSM(timeout, servers, natsOpts())
+	kingpin.FatalIfError(err, "setup failed")
 
 	if askSet {
 		c.messageSet, err = selectMessageSet(jsm, c.messageSet)

--- a/jsm/util.go
+++ b/jsm/util.go
@@ -196,9 +196,8 @@ func splitString(s string) []string {
 	})
 }
 
-func connect() (*nats.Conn, error) {
+func natsOpts() []nats.Option {
 	opts := []nats.Option{nats.Name("JetStream Management CLI"), nats.NoReconnect()}
-
 	if creds != "" {
 		opts = append(opts, nats.UserCredentials(creds))
 	}
@@ -211,5 +210,5 @@ func connect() (*nats.Conn, error) {
 		opts = append(opts, nats.RootCAs(tlsCA))
 	}
 
-	return nats.Connect(servers, opts...)
+	return opts
 }


### PR DESCRIPTION
Now takes server and nats options rather than a prepared nats connection