### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM golang:1.13.4-alpine3.10 AS builder
+
+WORKDIR $GOPATH/src/github.com/nats-io/jetstream
+
+RUN apk add -U --no-cache git binutils
+
+WORKDIR $GOPATH/src/github.com/nats-io/jetstream
+
+COPY . .
+
+RUN go install ./...
+RUN strip /go/bin/*
+
+FROM synadia/nats-box:latest
+
+RUN apk add --update ca-certificates
+
+COPY --from=builder /go/bin/* /usr/local/bin/
+
+ENTRYPOINT ["/bin/sh", "-l"]


### PR DESCRIPTION
Dockerfile to build image with the jsm util on top of the [nats-box](https://github.com/nats-io/nats-box) container

```sh
$ docker run -it synadia/nats-box:js # Just built locally this one, not on DockerHub
             _             _               
 _ __   __ _| |_ ___      | |__   _____  __
| '_ \ / _` | __/ __|_____| '_ \ / _ \ \/ /
| | | | (_| | |_\__ \_____| |_) | (_) >  < 
|_| |_|\__,_|\__|___/     |_.__/ \___/_/\_\
                                           
nats-box v0.2.0
1dfdc8249b8e:~# jsm
usage: jsm [<flags>] <command> [<args> ...]

JetStream Management Utility
```

Signed-off-by: Waldemar Quevedo <wally@synadia.com>