### PR TITLE
Fix Docker instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ $ docker run -ti --rm --entrypoint /nats-server --name js synadia/jsm:latest -js
 And in another log into the utilities:
 
 ```
-$ docker exec -ti js sh -l
+$ docker exec -ti -e NATS_URL=localhost js sh -l
 ```
 
 This shell has the `jsm` utility and all other NATS cli tools used in the rest of this guide.


### PR DESCRIPTION
To get the samples working in the README, I needed to set `NATS_URL=localhost` so that the `nats-*` commands can find the NATS server running locally