### PR TITLE
allow empty names in stream configurations

### DIFF
--- a/schemas/jetstream/api/v1/stream_configuration.json
+++ b/schemas/jetstream/api/v1/stream_configuration.json
@@ -5,7 +5,6 @@
   "title": "io.nats.jetstream.api.v1.stream_configuration",
   "type":"object",
   "required":[
-    "name",
     "retention",
     "max_consumers",
     "max_msgs",
@@ -18,7 +17,6 @@
   "properties": {
     "name": {
       "description": "A unique name for the Stream.",
-      "minLength": 1,
       "pattern": "^[^.*>]+$"
     },
     "subjects": {


### PR DESCRIPTION
This allows them to be used in Templates that *requires* an
empty stream name

Signed-off-by: R.I.Pienaar <rip@devco.net>