### PR TITLE
Refactor events command around templates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,8 @@ os:
   - windows
 
 go:
-  - 1.13.x
+  - 1.14.x
+
 env:
   - GO111MODULE=on
 install:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/nats-io/jetstream
 
-go 1.12
+go 1.14
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.0.7
@@ -11,7 +11,7 @@ require (
 	github.com/gosuri/uilive v0.0.4 // indirect
 	github.com/gosuri/uiprogress v0.0.1
 	github.com/guptarohit/asciigraph v0.4.1
-	github.com/nats-io/jsm.go v0.0.0-20200421110244-6d4426b19ae2
+	github.com/nats-io/jsm.go v0.0.0-20200429085926-19a5dfafa28b
 	github.com/nats-io/nats-server/v2 v2.1.7-0.20200420182537-915876db61ea
 	github.com/nats-io/nats.go v1.9.2
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190809123943-df4f5c81cb3b // indirect

--- a/go.sum
+++ b/go.sum
@@ -35,8 +35,8 @@ github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b h1:j7+1HpAFS1zy5+Q4qx1f
 github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
 github.com/minio/highwayhash v1.0.0 h1:iMSDhgUILCr0TNm8LWlSjF8N0ZIj2qbO8WHp6Q/J2BA=
 github.com/minio/highwayhash v1.0.0/go.mod h1:xQboMTeM9nY9v/LlAOxFctujiv5+Aq2hR5dxBpaMbdc=
-github.com/nats-io/jsm.go v0.0.0-20200421110244-6d4426b19ae2 h1:hxW11AfyowmvLSDk3psGfW2Eq0jim39qxNfwYAt7pkU=
-github.com/nats-io/jsm.go v0.0.0-20200421110244-6d4426b19ae2/go.mod h1:xvVxHmLmfDwusyIpsXWccrEuc7atGkh6axXRVftoEkA=
+github.com/nats-io/jsm.go v0.0.0-20200429085926-19a5dfafa28b h1:3cUGF4Q/chNZyxkwjPKIkpr9CSUq1vXSzvNhkxFw6Q0=
+github.com/nats-io/jsm.go v0.0.0-20200429085926-19a5dfafa28b/go.mod h1:xvVxHmLmfDwusyIpsXWccrEuc7atGkh6axXRVftoEkA=
 github.com/nats-io/jwt v0.3.2 h1:+RB5hMpXUUA2dfxuhBTEkMOrYmM+gKIZYS1KjSostMI=
 github.com/nats-io/jwt v0.3.2/go.mod h1:/euKqTS1ZD+zzjYrY7pseZrTtWQSjujC7xjPc8wL6eU=
 github.com/nats-io/nats-server/v2 v2.1.7-0.20200420182537-915876db61ea h1:VVtVd1lhtuTgNAsQB3CLLAOAadbi6bQMo7JcCve1qlg=

--- a/nats/events_command.go
+++ b/nats/events_command.go
@@ -2,17 +2,18 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net"
+	"os"
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
+	"text/template"
 	"time"
 
 	"github.com/dustin/go-humanize"
 	"github.com/nats-io/jsm.go/api"
-	"github.com/nats-io/nats-server/v2/server"
 	"github.com/nats-io/nats.go"
 	"gopkg.in/alecthomas/kingpin.v2"
 
@@ -31,10 +32,18 @@ type eventsCmd struct {
 	advisoriesF bool
 	allF        bool
 	connsF      bool
+	latencySubj []string
+
+	templates map[string]*template.Template
+
+	sync.Mutex
 }
 
 func configureEventsCommand(app *kingpin.Application) {
-	c := &eventsCmd{}
+	c := &eventsCmd{
+		templates: make(map[string]*template.Template),
+	}
+
 	events := app.Command("events", "Show Advisories and Events").Alias("event").Alias("e").Action(c.eventsAction)
 	events.Flag("all", "Show all events").Default("false").Short('a').BoolVar(&c.allF)
 	events.Flag("json", "Produce JSON output").Short('j').BoolVar(&c.json)
@@ -43,7 +52,201 @@ func configureEventsCommand(app *kingpin.Application) {
 	events.Flag("metrics", "Shows metric events (false)").Default("false").BoolVar(&c.metricsF)
 	events.Flag("advisories", "Shows advisory events (true)").Default("true").BoolVar(&c.advisoriesF)
 	events.Flag("connections", "Shows connections being opened and closed (false)").Default("false").BoolVar(&c.connsF)
+	events.Flag("latency", "Show service latency samples received on a specific subject").PlaceHolder("SUBJECT").Default("").StringsVar(&c.latencySubj)
+}
 
+func (c *eventsCmd) parseTemplates() (err error) {
+	t := map[string]string{}
+
+	t["io.nats.jetstream.advisory.v1.max_deliver"] = `
+[{{ .Time | ShortTime }}] [{{ .ID }}] Delivery Attempts Exceeded
+
+          Consumer: {{ .Stream }} > {{ .Consumer }}
+   Stream Sequence: {{ .StreamSeq }}
+        Deliveries: {{ .Deliveries }}
+`
+
+	t["io.nats.jetstream.advisory.v1.api_audit"] = `
+[{{ .Time | ShortTime }}] [{{ .ID }}] JetStream API Access
+
+      Server: {{ .Server }}
+     Subject: {{ .Subject }}
+      Client:
+{{- if .Client.User }}
+               User: {{ .Client.User }} Account: {{ .Client.Account }}
+{{- end }}
+               Host: {{ HostPort .Client.Host .Client.Port }}
+                CID: {{ .Client.CID }}
+{{- if .Client.Name }}
+               Name: {{ .Client.Name }}
+{{- end }}
+           Language: {{ .Client.Language }} {{ .Client.Version }}
+
+    Request:
+{{ if .Request }}
+{{ .Request | LeftPad 10 }}
+{{- else }}
+          Empty Request
+{{- end }}
+
+    Response:
+
+{{ .Response | LeftPad 10 }}
+`
+
+	t["io.nats.jetstream.metric.v1.consumer_ack"] = `
+[{{ .Time | ShortTime }}] [{{ .ID }}] Acknowledgment Sample
+
+              Consumer: {{ .Stream }} > {{ .Consumer }}
+       Stream Sequence: {{ .StreamSeq }}
+     Consumer Sequence: {{ .ConsumerSeq }}
+            Deliveries: {{ .Deliveries }}
+                 Delay: {{ .Delay }}
+`
+
+	t["io.nats.server.metric.v1.service_latency"] = `
+{{- if .Error }}
+[{{ .Time | ShortTime }}] [{{ .ID }}] Service Latency - {{ .Error }}
+{{- else }}
+[{{ .Time | ShortTime }}] [{{ .ID }}] Service Latency
+{{- end }}
+
+   Start Time: {{ .RequestStart | NanoTime }}
+{{- if .Error }}
+        Error: {{ .Error }}
+{{- end }}
+
+   Latencies:
+
+      Request Duration: {{ .TotalLatency }}
+{{- if .Requestor }}
+             Requestor: {{ .Requestor.RTT }}
+{{- end }}
+           NATS System: {{ .SystemLatency }}
+               Service: {{ .ServiceLatency }}
+{{ with .Requestor }}
+   Requestor:
+{{ if .User }}
+        User: {{ .User }}
+{{- end }}
+{{- if .Name }}
+        Name: {{ .Name }}
+{{- end }}
+{{- if .CID }}
+          IP: {{ .IP }}
+         CID: {{ .CID }}
+      Server: {{ .Server }}
+{{- end }}
+         RTT: {{ .RTT }}
+{{- end }}
+{{ with .Responder }}
+   Responder:
+{{ if .User }}
+        User: {{ .User }}
+{{- end }}
+{{- if .Name }}
+        Name: {{ .Name }}
+{{- end }}
+          IP: {{ .IP }}
+         CID: {{ .CID }}
+      Server: {{ .Server }}
+         RTT: {{ .RTT }}
+{{- end }}
+`
+
+	t["io.nats.server.advisory.v1.client_connect"] = `
+[{{ .Time | ShortTime }}] [{{ .ID }}] Client Disconnection
+
+{{- if .Reason }}
+   Reason: {{ .Reason }}
+{{- end }}
+   Server: {{ .Server.Name }}
+{{- if .Server.Cluster }}
+  Cluster: {{ .Server.Cluster }}
+{{- end }}
+
+   Client:
+            ID: {{ .Client.ID }}
+{{- if .Client.User }}
+          User: {{ .Client.User }}
+{{- end }}
+{{- if .Client.Name }}
+          Name: {{ .Client.Name }}
+{{- end }}
+       Account: {{ .Client.Account }}
+{{- if .Client.Lang }}
+      Language: {{ .Client.Lang }} {{ .Client.Version }}
+{{- end }}
+{{- if .Client.Host }}
+          Host: {{ .Client.Host }}
+{{- end }}
+{{ if .Stats }}
+   Stats:
+      Received: {{ .Received.Msgs }} messages ({{ .Received.Bytes | IBytes }})
+     Published: {{ .Sent.Msgs }} messages ({{ .Sent.Bytes | IBytes }})
+           RTT: {{ .Client.RTT }}
+{{- end }}
+`
+
+	t["io.nats.server.advisory.v1.client_disconnect"] = t["io.nats.server.advisory.v1.client_connect"]
+
+	for k, tmpl := range t {
+		c.templates[k], err = template.New(k).Funcs(map[string]interface{}{
+			"ShortTime": func(v time.Time) string { return v.Format("15:04:05") },
+			"NanoTime":  func(v time.Time) string { return v.Format("15:04:05.000") },
+			"IBytes":    func(v int64) string { return humanize.IBytes(uint64(v)) },
+			"HostPort":  func(h string, p int) string { return net.JoinHostPort(h, strconv.Itoa(p)) },
+			"LeftPad":   func(indent int, v string) string { return leftPad(v, indent) },
+		}).Parse(tmpl)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+func (c *eventsCmd) handleNATSEvent(m *nats.Msg) {
+	if !c.bodyFRe.MatchString(strings.ToUpper(string(m.Data))) {
+		return
+	}
+
+	if !c.subjectFRe.MatchString(strings.ToUpper(m.Subject)) {
+		return
+	}
+
+	if c.json {
+		fmt.Println(string(m.Data))
+		return
+	}
+
+	handle := func() error {
+		kind, event, err := jsm.ParseEvent(m.Data)
+		if err != nil {
+			return fmt.Errorf("parsing failed: %s", err)
+		}
+
+		if kind == "io.nats.unknown_event" {
+			return fmt.Errorf("unknown event")
+		}
+
+		tmpl, ok := c.templates[kind]
+		if !ok {
+			return fmt.Errorf("unknown template for %s", kind)
+		}
+
+		err = tmpl.Execute(os.Stdout, event)
+		if err != nil {
+			return fmt.Errorf("display failed: %s", err)
+		}
+
+		return nil
+	}
+
+	err := handle()
+	if err != nil {
+		fmt.Printf("Event error: %s\n\n", err)
+		fmt.Println(leftPad(string(m.Data), 10))
+	}
 }
 
 func (c *eventsCmd) Printf(f string, arg ...interface{}) {
@@ -53,6 +256,11 @@ func (c *eventsCmd) Printf(f string, arg ...interface{}) {
 }
 
 func (c *eventsCmd) eventsAction(_ *kingpin.ParseContext) error {
+	err := c.parseTemplates()
+	if err != nil {
+		kingpin.Fatalf(err.Error())
+	}
+
 	nc, err := prepareHelper(servers, natsOpts()...)
 	kingpin.FatalIfError(err, "setup failed")
 
@@ -64,27 +272,36 @@ func (c *eventsCmd) eventsAction(_ *kingpin.ParseContext) error {
 	if c.advisoriesF || c.allF {
 		c.Printf("Listening for Advisories on %s.>\n", api.JetStreamAdvisoryPrefix)
 		nc.Subscribe(fmt.Sprintf("%s.>", api.JetStreamAdvisoryPrefix), func(m *nats.Msg) {
-			c.renderAdvisory(m)
+			c.handleNATSEvent(m)
 		})
 	}
 
 	if c.metricsF || c.allF {
 		c.Printf("Listening for Metrics on %s.>\n", api.JetStreamMetricPrefix)
 		nc.Subscribe(fmt.Sprintf("%s.>", api.JetStreamMetricPrefix), func(m *nats.Msg) {
-			c.renderMetric(m)
+			c.handleNATSEvent(m)
 		})
 	}
 
 	if c.connsF || c.allF {
 		c.Printf("Listening for Client Connection events on $SYS.ACCOUNT.*.CONNECT\n")
 		nc.Subscribe("$SYS.ACCOUNT.*.CONNECT", func(m *nats.Msg) {
-			c.renderConnection(m)
+			c.handleNATSEvent(m)
 		})
 
 		c.Printf("Listening for Client Disconnection events on $SYS.ACCOUNT.*.DISCONNECT\n")
 		nc.Subscribe("$SYS.ACCOUNT.*.DISCONNECT", func(m *nats.Msg) {
-			c.renderDisconnection(m)
+			c.handleNATSEvent(m)
 		})
+	}
+
+	if len(c.latencySubj) > 0 {
+		for _, s := range c.latencySubj {
+			c.Printf("Listening for latency samples on %s\n", s)
+			nc.Subscribe(s, func(m *nats.Msg) {
+				c.handleNATSEvent(m)
+			})
+		}
 	}
 
 	<-context.Background().Done()
@@ -92,17 +309,8 @@ func (c *eventsCmd) eventsAction(_ *kingpin.ParseContext) error {
 	return nil
 }
 
-func parseTime(t string) time.Time {
-	tstamp, err := time.Parse(time.RFC3339, t)
-	if err != nil {
-		tstamp = time.Now().UTC()
-	}
-
-	return tstamp
-}
-
 func leftPad(s string, indent int) string {
-	out := []string{}
+	var out []string
 	format := fmt.Sprintf("%%%ds", indent)
 
 	for _, l := range strings.Split(s, "\n") {
@@ -110,216 +318,4 @@ func leftPad(s string, indent int) string {
 	}
 
 	return strings.Join(out, "\n")
-}
-
-func (c *eventsCmd) renderDisconnection(m *nats.Msg) {
-	if !c.subjectFRe.MatchString(strings.ToUpper(m.Subject)) {
-		return
-	}
-
-	if !c.bodyFRe.MatchString(strings.ToUpper(string(m.Data))) {
-		return
-	}
-
-	if c.json {
-		fmt.Println(string(m.Data))
-		return
-	}
-
-	event := server.DisconnectEventMsg{}
-	err := json.Unmarshal(m.Data, &event)
-	if err != nil {
-		fmt.Printf("Event parsing failed: %s\n\n", err)
-		fmt.Println(leftPad(string(m.Data), 10))
-		return
-	}
-
-	fmt.Printf("[%s] [%d] Client Disconnection\n", event.Server.Time.Format("15:04:05"), event.Server.Seq)
-	fmt.Printf("   Reason: %s\n", event.Reason)
-	fmt.Printf("   Server: %s\n", event.Server.Name)
-	fmt.Println()
-	fmt.Println("   Client:")
-	fmt.Printf("            ID: %d\n", event.Client.ID)
-	if event.Client.User != "" {
-		fmt.Printf("          User: %s\n", event.Client.User)
-	}
-	if event.Client.Name != "" {
-		fmt.Printf("          Name: %s\n", event.Client.Name)
-	}
-	fmt.Printf("       Account: %s\n", event.Client.Account)
-	fmt.Println()
-	fmt.Println("   Stats:")
-	fmt.Printf("      Received: %d messages (%s)\n", event.Received.Msgs, humanize.IBytes(uint64(event.Received.Bytes)))
-	fmt.Printf("     Published: %d messages (%s)\n", event.Sent.Msgs, humanize.IBytes(uint64(event.Sent.Bytes)))
-	fmt.Println()
-}
-
-func (c *eventsCmd) renderConnection(m *nats.Msg) {
-	if !c.subjectFRe.MatchString(strings.ToUpper(m.Subject)) {
-		return
-	}
-	if !c.bodyFRe.MatchString(strings.ToUpper(string(m.Data))) {
-		return
-	}
-
-	if c.json {
-		fmt.Println(string(m.Data))
-		return
-	}
-
-	event := server.ConnectEventMsg{}
-	err := json.Unmarshal(m.Data, &event)
-	if err != nil {
-		fmt.Printf("Event parsing failed: %s\n\n", err)
-		fmt.Println(leftPad(string(m.Data), 10))
-		return
-	}
-
-	fmt.Printf("[%s] [%d] Client Connection\n", event.Server.Time.Format("15:04:05"), event.Server.Seq)
-	fmt.Println("   Server:")
-	fmt.Printf("          Name: %s\n", event.Server.Name)
-	if event.Server.Cluster != "" {
-		fmt.Printf("       Cluster: %s\n", event.Server.Cluster)
-	}
-	fmt.Println()
-	fmt.Println("   Client:")
-	fmt.Printf("          ID: %d\n", event.Client.ID)
-	if event.Client.User != "" {
-		fmt.Printf("        User: %s\n", event.Client.User)
-	}
-	if event.Client.Name != "" {
-		fmt.Printf("        Name: %s\n", event.Client.Name)
-	}
-	fmt.Printf("     Account: %s\n", event.Client.Account)
-	fmt.Printf("    Language: %s\n", event.Client.Lang)
-	fmt.Printf("     Version: %s\n", event.Client.Version)
-	fmt.Printf("        Host: %s\n", event.Client.Host)
-	fmt.Println()
-}
-
-func (c *eventsCmd) renderDeliveryExceeded(event *api.ConsumerDeliveryExceededAdvisory, m *nats.Msg) {
-	if !c.subjectFRe.MatchString(strings.ToUpper(m.Subject)) {
-		return
-	}
-
-	if c.json {
-		fmt.Println(string(m.Data))
-		return
-	}
-
-	fmt.Printf("[%s] [%s] Delivery Attempts Exceeded\n", parseTime(event.Time).Format("15:04:05"), event.ID)
-	fmt.Printf("         Consumer: %s > %s\n", event.Stream, event.Consumer)
-	fmt.Printf("  Stream Sequence: %d\n", event.StreamSeq)
-	fmt.Printf("       Deliveries: %d\n", event.Deliveries)
-	fmt.Println()
-}
-
-func (c *eventsCmd) renderAPIAudit(event *api.JetStreamAPIAudit, m *nats.Msg) {
-	if !c.subjectFRe.MatchString(strings.ToUpper(event.Subject)) {
-		return
-	}
-
-	if c.json {
-		fmt.Println(string(m.Data))
-		return
-	}
-
-	fmt.Printf("[%s] [%s] API Access\n", parseTime(event.Time).Format("15:04:05"), event.ID)
-	fmt.Printf("      Server: %s\n", event.Server)
-	fmt.Printf("     Subject: %s\n", event.Subject)
-	fmt.Printf("      Client:\n")
-	if event.Client.User != "" {
-		fmt.Printf("               User: %s Account: %s\n", event.Client.User, event.Client.Account)
-	} else {
-		fmt.Printf("            Account: %s\n", event.Client.Account)
-	}
-	fmt.Printf("               Host: %s\n", net.JoinHostPort(event.Client.Host, strconv.Itoa(event.Client.Port)))
-	fmt.Printf("                 ID: %d\n", event.Client.CID)
-	if event.Client.Name != "" {
-		fmt.Printf("               Name: %s\n", event.Client.Name)
-	}
-	if event.Client.Language != "" && event.Client.Version != "" {
-		fmt.Printf("            Lanuage: %s %s\n", event.Client.Language, event.Client.Version)
-	}
-	fmt.Println()
-
-	fmt.Println("    Request:")
-	fmt.Println()
-	if event.Request != "" {
-		fmt.Println(leftPad(event.Request, 10))
-	} else {
-		fmt.Println("          Empty Request")
-	}
-	fmt.Println()
-
-	if event.Response != "" {
-		fmt.Println("    Response:")
-		fmt.Println()
-		fmt.Println(leftPad(event.Response, 10))
-	}
-	fmt.Println()
-}
-
-func (c *eventsCmd) renderAckSample(event *api.ConsumerAckMetric, m *nats.Msg) {
-	if !c.subjectFRe.MatchString(strings.ToUpper(m.Subject)) {
-		return
-	}
-
-	if c.json {
-		fmt.Println(string(m.Data))
-		return
-	}
-
-	fmt.Printf("[%s] [%s] Acknowledgement Sample\n", parseTime(event.Time).Format("15:04:05"), event.ID)
-	fmt.Printf("              Consumer: %s > %s\n", event.Stream, event.Consumer)
-	fmt.Printf("       Stream Sequence: %d\n", event.StreamSeq)
-	fmt.Printf("     Consumer Sequence: %d\n", event.ConsumerSeq)
-	fmt.Printf("            Deliveries: %d\n", event.Deliveries)
-	fmt.Printf("                 Delay: %v\n", time.Duration(event.Delay))
-	fmt.Println()
-}
-
-func (c *eventsCmd) renderAdvisory(m *nats.Msg) {
-	if !c.bodyFRe.MatchString(strings.ToUpper(string(m.Data))) {
-		return
-	}
-
-	_, event, err := jsm.ParseEvent(m.Data)
-	if err != nil {
-		fmt.Printf("Event parsing failed: %s\n\n", err)
-		fmt.Println(leftPad(string(m.Data), 10))
-		return
-	}
-
-	switch event := event.(type) {
-	case *api.ConsumerDeliveryExceededAdvisory:
-		c.renderDeliveryExceeded(event, m)
-
-	case *api.JetStreamAPIAudit:
-		c.renderAPIAudit(event, m)
-
-	default:
-		fmt.Println(string(m.Data))
-	}
-}
-
-func (c *eventsCmd) renderMetric(m *nats.Msg) {
-	if !c.bodyFRe.MatchString(strings.ToUpper(string(m.Data))) {
-		return
-	}
-
-	_, event, err := jsm.ParseEvent(m.Data)
-	if err != nil {
-		fmt.Printf("Event parsing failed: %s\n\n", err)
-		fmt.Println(leftPad(string(m.Data), 10))
-		return
-	}
-
-	switch event := event.(type) {
-	case *api.ConsumerAckMetric:
-		c.renderAckSample(event, m)
-
-	default:
-		fmt.Println(string(m.Data))
-	}
 }


### PR DESCRIPTION
This refactors the events command from many printfs to text
templates which is a lot more maintainable

Add support for new service latency messages and the ability
to sleep randomly when replying

Signed-off-by: R.I.Pienaar <rip@devco.net>