### PR TITLE
build nats-server locally during docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,16 @@
-FROM synadia/nats-server:2.2.0-JS-preview AS JS
+FROM golang:1.14-alpine AS SERVER
+
+RUN apk add --update git
+RUN mkdir -p src/github.com/nats-io && \
+    cd src/github.com/nats-io/ && \
+    git clone https://github.com/nats-io/nats-server.git
+RUN cd src/github.com/nats-io/nats-server && CGO_ENABLED=0 GO111MODULE=off go build -v -a -tags netgo -installsuffix netgo -ldflags "-s -w -X github.com/nats-io/nats-server/server.gitCommit=`git rev-parse --short HEAD`" -o /nats-server
+
 FROM stedolan/jq:latest AS JQ
 FROM synadia/nats-box:latest
 
-COPY --from=JS /nats-server /nats-server
 COPY --from=JQ /usr/local/bin/jq /usr/local/bin/jq
+COPY --from=SERVER /nats-server /nats-server
 
 # goreleaser does the build
 COPY nats /usr/local/bin/


### PR DESCRIPTION
This is to prepare for publishing jetstream images nightly

Signed-off-by: R.I.Pienaar <rip@devco.net>