### PR TITLE
do not prompt interactively during force

### DIFF
--- a/nats/consumer_command.go
+++ b/nats/consumer_command.go
@@ -651,11 +651,11 @@ func (c *consumerCmd) connectAndSetup(askStream bool, askConsumer bool) {
 	kingpin.FatalIfError(err, "setup failed")
 
 	if askStream {
-		c.stream, err = selectStream(c.stream)
+		c.stream, err = selectStream(c.stream, c.force)
 		kingpin.FatalIfError(err, "could not select Stream")
 
 		if askConsumer {
-			c.consumer, err = selectConsumer(c.stream, c.consumer)
+			c.consumer, err = selectConsumer(c.stream, c.consumer, c.force)
 			kingpin.FatalIfError(err, "could not select Consumer")
 		}
 	}

--- a/nats/stream_command.go
+++ b/nats/stream_command.go
@@ -152,7 +152,7 @@ func (c *streamCmd) streamTemplateRm(_ *kingpin.ParseContext) (err error) {
 	_, err = prepareHelper(servers, natsOpts()...)
 	kingpin.FatalIfError(err, "setup failed")
 
-	c.stream, err = selectStreamTemplate(c.stream)
+	c.stream, err = selectStreamTemplate(c.stream, c.force)
 	kingpin.FatalIfError(err, "could not pick a Stream Template to operate on")
 
 	template, err := jsm.LoadStreamTemplate(c.stream)
@@ -204,7 +204,7 @@ func (c *streamCmd) streamTemplateInfo(_ *kingpin.ParseContext) error {
 	_, err := prepareHelper(servers, natsOpts()...)
 	kingpin.FatalIfError(err, "setup failed")
 
-	c.stream, err = selectStreamTemplate(c.stream)
+	c.stream, err = selectStreamTemplate(c.stream, c.force)
 	kingpin.FatalIfError(err, "could not pick a Stream Template to operate on")
 
 	info, err := jsm.LoadStreamTemplate(c.stream)
@@ -906,6 +906,6 @@ func (c *streamCmd) connectAndAskStream() {
 	_, err := prepareHelper(servers, natsOpts()...)
 	kingpin.FatalIfError(err, "setup failed")
 
-	c.stream, err = selectStream(c.stream)
+	c.stream, err = selectStream(c.stream, c.force)
 	kingpin.FatalIfError(err, "could not pick a Stream to operate on")
 }

--- a/nats/util.go
+++ b/nats/util.go
@@ -31,7 +31,7 @@ import (
 	"github.com/nats-io/jsm.go"
 )
 
-func selectConsumer(stream string, consumer string) (string, error) {
+func selectConsumer(stream string, consumer string, force bool) (string, error) {
 	if consumer != "" {
 		known, err := jsm.IsKnownConsumer(stream, consumer)
 		if err != nil {
@@ -41,6 +41,10 @@ func selectConsumer(stream string, consumer string) (string, error) {
 		if known {
 			return consumer, nil
 		}
+	}
+
+	if force {
+		return "", fmt.Errorf("unknown consumer %q > %q", stream, consumer)
 	}
 
 	consumers, err := jsm.ConsumerNames(stream)
@@ -66,7 +70,7 @@ func selectConsumer(stream string, consumer string) (string, error) {
 	}
 }
 
-func selectStreamTemplate(template string) (string, error) {
+func selectStreamTemplate(template string, force bool) (string, error) {
 	if template != "" {
 		known, err := jsm.IsKnownStreamTemplate(template)
 		if err != nil {
@@ -76,6 +80,10 @@ func selectStreamTemplate(template string) (string, error) {
 		if known {
 			return template, nil
 		}
+	}
+
+	if force {
+		return "", fmt.Errorf("unknown template %q", template)
 	}
 
 	templates, err := jsm.StreamTemplateNames()
@@ -101,7 +109,7 @@ func selectStreamTemplate(template string) (string, error) {
 	}
 }
 
-func selectStream(stream string) (string, error) {
+func selectStream(stream string, force bool) (string, error) {
 	if stream != "" {
 		known, err := jsm.IsKnownStream(stream)
 		if err != nil {
@@ -111,6 +119,10 @@ func selectStream(stream string) (string, error) {
 		if known {
 			return stream, nil
 		}
+	}
+
+	if force {
+		return "", fmt.Errorf("unknown stream %q", stream)
 	}
 
 	streams, err := jsm.StreamNames()


### PR DESCRIPTION
Previously when --force was specified on actions like rm, edit,
purge etc it would interactively prompt for a stream if the chosen
stream does not exist.

Now it will assume the user know what they wanted and exit with
an error on unknown stream, consumer or template instead

Signed-off-by: R.I.Pienaar <rip@devco.net>