### PR TITLE
fix reply queue group handling

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,9 +12,10 @@ require (
 	github.com/gosuri/uilive v0.0.4 // indirect
 	github.com/gosuri/uiprogress v0.0.1
 	github.com/guptarohit/asciigraph v0.4.2
+	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/nats-io/jsm.go v0.0.18-0.20200728184527-b203f0d7a1de
 	github.com/nats-io/nats-server/v2 v2.1.8-0.20200727232909-fbab1daf063e
-	github.com/nats-io/nats.go v1.10.1-0.20200606002146-fc6fed82929a
+	github.com/nats-io/nats.go v1.10.1-0.20200720131241-97eff70ce747
 	github.com/tylertreat/hdrhistogram-writer v0.0.0-20180430173243-73b8d31ba571
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
 	github.com/xlab/tablewriter v0.0.0-20160610135559-80b567a11ad5

--- a/go.sum
+++ b/go.sum
@@ -66,12 +66,15 @@ github.com/nats-io/jwt/v2 v2.0.0-20200602193336-473d698956ed h1:nnV8Mw23aNwNpKuQ
 github.com/nats-io/jwt/v2 v2.0.0-20200602193336-473d698956ed/go.mod h1:vs+ZEjP+XKy8szkBmQwCB7RjYdIlMaPsFPs4VdS4bTQ=
 github.com/nats-io/nats-server/v2 v2.1.8-0.20200524125952-51ebd92a9093/go.mod h1:rQnBf2Rv4P9adtAs/Ti6LfFmVtFG6HLhl/H7cVshcJU=
 github.com/nats-io/nats-server/v2 v2.1.8-0.20200601203034-f8d6dd992b71/go.mod h1:Nan/1L5Sa1JRW+Thm4HNYcIDcVRFc5zK9OpSZeI2kk4=
+github.com/nats-io/nats-server/v2 v2.1.8-0.20200617224755-fa744fdcdaa3/go.mod h1:uXGA6y1uxwW755SK+LoDZggh+UUVsbVoxh8ZG8MqbsI=
 github.com/nats-io/nats-server/v2 v2.1.8-0.20200727232909-fbab1daf063e h1:PgTuDD7PI48zAO/wnWcMjw/XwpdKVK/XDCsDOAdCPE8=
 github.com/nats-io/nats-server/v2 v2.1.8-0.20200727232909-fbab1daf063e/go.mod h1:MDO4flDityyw4YxR+/rbdcSzlO+Rw6SbY95tHkrd6EU=
 github.com/nats-io/nats.go v1.10.0/go.mod h1:AjGArbfyR50+afOUotNX2Xs5SYHf+CoOa5HH1eEl2HE=
 github.com/nats-io/nats.go v1.10.1-0.20200531124210-96f2130e4d55/go.mod h1:ARiFsjW9DVxk48WJbO3OSZ2DG8fjkMi7ecLmXoY/n9I=
 github.com/nats-io/nats.go v1.10.1-0.20200606002146-fc6fed82929a h1:gzSKZOBlu/DpbuPbt34paXCOvA6+E+lVfU2BmomQ9HA=
 github.com/nats-io/nats.go v1.10.1-0.20200606002146-fc6fed82929a/go.mod h1:8eAIv96Mo9QW6Or40jUHejS7e4VwZ3VRYD6Sf0BTDp4=
+github.com/nats-io/nats.go v1.10.1-0.20200720131241-97eff70ce747 h1:8W4FzvhTLzBbel1DiQ681HQP0u18g6grtda075cKfqA=
+github.com/nats-io/nats.go v1.10.1-0.20200720131241-97eff70ce747/go.mod h1:lXT/jvLMdMK0eWLKMgi/pcIVh26ks62QyT7ZQeocosM=
 github.com/nats-io/nkeys v0.1.3/go.mod h1:xpnFELMwJABBLVhffcfd1MZx6VsNRFpEugbxziKVo7w=
 github.com/nats-io/nkeys v0.1.4/go.mod h1:XdZpAbhgyyODYqjTawOnIOI7VlbKSarI9Gfy1tqEu/s=
 github.com/nats-io/nkeys v0.2.0 h1:WXKF7diOaPU9cJdLD7nuzwasQy9vT1tBqzXZZf3AMJM=

--- a/nats/pub_command.go
+++ b/nats/pub_command.go
@@ -77,7 +77,7 @@ func (c *pubCmd) publish(pc *kingpin.ParseContext) error {
 
 	if c.req {
 		if !c.raw {
-			log.Printf("Sending request on [%s]\n", c.subject)
+			log.Printf("Sending request on %q\n", c.subject)
 		}
 
 		msg, err := c.prepareMsg()
@@ -96,7 +96,7 @@ func (c *pubCmd) publish(pc *kingpin.ParseContext) error {
 			return nil
 		}
 
-		log.Printf("Received on [%s]", m.Subject)
+		log.Printf("Received on %q", m.Subject)
 		if len(m.Header) > 0 {
 			for h, vals := range m.Header {
 				for _, val := range vals {
@@ -131,7 +131,7 @@ func (c *pubCmd) publish(pc *kingpin.ParseContext) error {
 		return err
 	}
 
-	log.Printf("Published %d bytes to %s\n", len(c.body), c.subject)
+	log.Printf("Published %d bytes to %q\n", len(c.body), c.subject)
 
 	return nil
 }


### PR DESCRIPTION
Additionally:

 * Improve UX
 * Add --command to source the reply data externally

The --command can have token place holders like {{1}} which will
be replaced with the first token in the subject before execution

When --command is run the environment variables NATS_REQUEST_BODY
and NATS_REQUEST_SUJECT are set.

reply -q wttr 'weather.>' --command "curl -s wttr.in/{{1}}?format=3"

Makes a dynamic weather service

Signed-off-by: R.I.Pienaar <rip@devco.net>