### PR TITLE
Support NATS_CONTEXT env-var

### DIFF
--- a/nats/main.go
+++ b/nats/main.go
@@ -29,6 +29,8 @@ var (
 	// used during tests
 	skipContexts bool
 
+	// These are persisted by contexts, as properties thereof.
+	// So don't include NATS_CONTEXT in this list.
 	overrideEnvVars = []string{"NATS_URL", "NATS_USER", "NATS_PASSWORD", "NATS_CREDS", "NATS_NKEY", "NATS_CERT", "NATS_KEY", "NATS_CA", "NATS_TIMEOUT"}
 )
 
@@ -51,7 +53,7 @@ func main() {
 	ncli.Flag("tlskey", "TLS private key").Envar("NATS_KEY").PlaceHolder("NATS_KEY").ExistingFileVar(&tlsKey)
 	ncli.Flag("tlsca", "TLS certificate authority chain").Envar("NATS_CA").PlaceHolder("NATS_CA").ExistingFileVar(&tlsCA)
 	ncli.Flag("timeout", "Time to wait on responses from NATS").Default("2s").Envar("NATS_TIMEOUT").PlaceHolder("NATS_TIMEOUT").DurationVar(&timeout)
-	ncli.Flag("context", "Configuration context").StringVar(&cfgCtx)
+	ncli.Flag("context", "Configuration context").Envar("NATS_CONTEXT").StringVar(&cfgCtx)
 	ncli.Flag("trace", "Trace API interactions").BoolVar(&trace)
 
 	ncli.PreAction(prepareConfig)


### PR DESCRIPTION
Allowing the context to come from an environment variable plays well with tools such as direnv when managing multiple different clusters and wanting to switch automatically to "the current one for code in this directory".